### PR TITLE
Update URL and deploy via serverless

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -29,12 +29,12 @@ def send_file(path):
 
 def main(event, context):
 
-    page_link = 'http://www.bom.gov.au/products/IDR663.loop.shtml'
+    page_link = 'https://reg.bom.gov.au/products/IDR663.loop.shtml'
 
-    locations_link = 'http://www.bom.gov.au/products/radar_transparencies/IDR663.locations.png'
-    topography_link = 'http://www.bom.gov.au/products/radar_transparencies/IDR663.topography.png'
-    range_link = 'http://www.bom.gov.au/products/radar_transparencies/IDR663.range.png'
-    background_link = 'http://www.bom.gov.au/products/radar_transparencies/IDR663.background.png'
+    locations_link = 'https://reg.bom.gov.au/products/radar_transparencies/IDR663.locations.png'
+    topography_link = 'https://reg.bom.gov.au/products/radar_transparencies/IDR663.topography.png'
+    range_link = 'https://reg.bom.gov.au/products/radar_transparencies/IDR663.range.png'
+    background_link = 'https://reg.bom.gov.au/products/radar_transparencies/IDR663.background.png'
 
     headers = {
         'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.142 Safari/537.36'
@@ -50,7 +50,7 @@ def main(event, context):
     gif_images = []
 
     for link in gif_links:
-        response = requests.get("http://www.bom.gov.au" + link, headers=headers)
+        response = requests.get("https://reg.bom.gov.au" + link, headers=headers)
         gif_images.append(Image.open(BytesIO(response.content)).convert("RGBA"))
 
     response = requests.get(range_link, headers=headers)


### PR DESCRIPTION
Updated all BOM URL references from http://www.bom.gov.au to https://reg.bom.gov.au/ in handler.py to use the new BOM registry domain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)